### PR TITLE
Remove link to old documentation

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,3 @@
-<div class="old-documentation">
-    Qui puoi visualizzare la <strong><a target="_blank" href="https://legacy.docs.nethesis.it">versione precedente di nethipedia</a></strong>
-</div>
 <footer class="footer first-footer">
     <div class="container">
         <div class="columns">


### PR DESCRIPTION
The host legacy.docs.nethesis.it has been dismissed